### PR TITLE
Modify rotary switch api to accommodate multiple rotary switches

### DIFF
--- a/source/apps/badge_monsters.c
+++ b/source/apps/badge_monsters.c
@@ -471,7 +471,7 @@ static void check_the_buttons(void)
 {
     int something_changed = 0;
     int down_latches = button_down_latches();
-    int rotary = button_get_rotation();
+    int rotary = button_get_rotation(0);
 
     /* If we are trading monsters, stop trading monsters on a button press */
     if (trading_monsters_enabled) {

--- a/source/apps/qc.c
+++ b/source/apps/qc.c
@@ -167,7 +167,7 @@ void QC_cb()
                 redraw = 1;
             }
 
-            int rotation = button_get_rotation();
+            int rotation = button_get_rotation(0);
             if (rotation < 0) {
                 audio_out_beep(440, 100);
             } else if (rotation > 0) {

--- a/source/apps/smashout.c
+++ b/source/apps/smashout.c
@@ -109,7 +109,7 @@ static void smashout_game_init(void)
 
 static void smashout_check_buttons()
 {
-	int rotary_switch = button_get_rotation();
+	int rotary_switch = button_get_rotation(0);
 	int down_latches = button_down_latches();
 
 	if (BUTTON_PRESSED(BADGE_BUTTON_SW, down_latches))

--- a/source/apps/spacetripper.c
+++ b/source/apps/spacetripper.c
@@ -1023,7 +1023,7 @@ static void show_energy_and_torps(void)
 static void st_choose_angle_input(void)
 {
 	int down_latches = button_down_latches();
-	int rotary = button_get_rotation();
+	int rotary = button_get_rotation(0);
 	int something_changed = 0;
 
 	gs.angle_chooser.old_angle = *gs.angle_chooser.angle;
@@ -1160,7 +1160,7 @@ static void st_choose_weapons(void)
 static void st_process_input(void)
 {
     int down_latches = button_down_latches();
-    int rotary = button_get_rotation();
+    int rotary = button_get_rotation(0);
     int something_happened = 0;
     if (BUTTON_PRESSED(BADGE_BUTTON_SW, down_latches)) {
         button_pressed();
@@ -2088,7 +2088,7 @@ static void st_warp_input(void)
 	int old = gs.player.new_warp_factor;
 
 	int down_latches = button_down_latches();
-	int rotary = button_get_rotation();
+	int rotary = button_get_rotation(0);
 	if (BUTTON_PRESSED(BADGE_BUTTON_SW, down_latches)) {
 		gs.player.warp_factor = gs.player.new_warp_factor;
 		st_warp();
@@ -2215,7 +2215,7 @@ static void st_shield_energy_input()
 		min = -max_ship;
 
 	int down_latches = button_down_latches();
-	int rotary = button_get_rotation();
+	int rotary = button_get_rotation(0);
 	if (BUTTON_PRESSED(BADGE_BUTTON_SW, down_latches)) {
 		gs.player.shield_xfer = gs.player.new_shield_xfer;
 		st_program_state = ST_SHIELD_EXEC_ENERGY_XFER;
@@ -2276,7 +2276,7 @@ static void st_shield_exec_energy_xfer(void)
 static void st_phaser_power_input(void)
 {
 	int down_latches = button_down_latches();
-	int rotary = button_get_rotation();
+	int rotary = button_get_rotation(0);
 	int old = gs.player.new_phaser_power;
 
 	if (BUTTON_PRESSED(BADGE_BUTTON_SW, down_latches)) {

--- a/source/core/menu.c
+++ b/source/core/menu.c
@@ -275,7 +275,7 @@ void menus() {
     }
 
     int down_latches = button_down_latches();
-    int rotary = button_get_rotation();
+    int rotary = button_get_rotation(0);
     /* see if physical button has been clicked */
     if (BUTTON_PRESSED(BADGE_BUTTON_SW, down_latches)) {
         // action happened that will result in menu redraw

--- a/source/hal/button.h
+++ b/source/hal/button.h
@@ -42,7 +42,7 @@ void button_reset_last_input_timestamp(void);
 
 // Get rotary encoder rotations! Rotation count is automatically cleared between calls.
 // Positive indicates CW, negative indicates CCW.
-int button_get_rotation(void);
+int button_get_rotation(int which_rotary);
 
 /**  Tell us if we're busy debouncing a button input. */
 bool button_debouncing(void);

--- a/source/hal/button_rp2040.c
+++ b/source/hal/button_rp2040.c
@@ -163,7 +163,8 @@ void button_reset_last_input_timestamp(void) {
     last_change = rtc_get_ms_since_boot();
 }
 
-int button_get_rotation(void) {
+/* TODO: make this work with multiple rotary switches */
+int button_get_rotation(__attribute__((unused)) int which_rotary) {
     critical_section_enter_blocking(&critical_section);
     int count = rotation_count;
     rotation_count = 0;

--- a/source/hal/button_sdl_sim.c
+++ b/source/hal/button_sdl_sim.c
@@ -152,7 +152,8 @@ void button_reset_last_input_timestamp(void) {
     last_change = rtc_get_ms_since_boot();
 }
 
-int button_get_rotation(void) {
+/* TODO: make this work with multiple rotary switches */
+int button_get_rotation(__attribute__((unused)) int which_rotary) {
     int count = rotation_count;
     rotation_count = 0;
     return count;

--- a/source/hal/button_sim.c
+++ b/source/hal/button_sim.c
@@ -154,7 +154,7 @@ void button_reset_last_input_timestamp(void) {
     last_change = rtc_get_ms_since_boot();
 }
 
-int button_get_rotation(void) {
+int button_get_rotation(__attribute__((unused)) int which_rotary) {
     int count = rotation_count;
     rotation_count = 0;
     return count;


### PR DESCRIPTION
Hey, Peter and Sam, I propose this change to the rotary API to allow for the possibility of multiple switches.  I just changed button_get_rotation() to be button_get_rotation(int which_rotary);

This patch doesn't implement anything yet other than adding the parameter to the API.

If there's no objections in a couple days, I'll commit it.

-- steve